### PR TITLE
Closes #39: Change topmenu languages to native

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,14 +46,14 @@
   <a href="http://127.0.0.1:43110/Talk.ZeroNetwork.bit">Main</a> &middot;
   <a href="http://127.0.0.1:43110/165eqHdoQfyf7CVGqtVCGNDvMBZhwVSJBL">Español</a> &middot;
   <a href="http://127.0.0.1:43110/1Vp5LH4wegCaqeB72yMw2jgNdVm4aR7ET">Français</a> &middot;
-  <a href="http://127.0.0.1:43110/1E4XLtKC59YV8V9JQ4AkeqSvqECSvrUtnv">German</a> &middot;
-  <a href="http://127.0.0.1:43110/1NPAmKPbZU33tAStGqygs8FD2bRq7zYoHb">Hungarian</a> &middot;
-  <a href="http://127.0.0.1:43110/1MxvDmGn5fipn7cyjXAMyMZPH3SyhwfZkw/">Italian</a> &middot;
-  <a href="http://127.0.0.1:43110/1GRYnz73jSXoMMZNU3nSmbCFA3twuitcoo">Polish</a> &middot;
+  <a href="http://127.0.0.1:43110/1E4XLtKC59YV8V9JQ4AkeqSvqECSvrUtnv">Deutsch</a> &middot;
+  <a href="http://127.0.0.1:43110/1NPAmKPbZU33tAStGqygs8FD2bRq7zYoHb">Magyar</a> &middot;
+  <a href="http://127.0.0.1:43110/1MxvDmGn5fipn7cyjXAMyMZPH3SyhwfZkw/">Italiano</a> &middot;
+  <a href="http://127.0.0.1:43110/1GRYnz73jSXoMMZNU3nSmbCFA3twuitcoo">Polski</a> &middot;
   <a href="http://127.0.0.1:43110/1LULE6frq3kw2vbhe4i6ArUTo4YT99Czbj">Português</a> &middot;
   <a href="http://127.0.0.1:43110/1DKi1k1V3WAkKwxKqySDmknVNTccBmJ7Ku">Québec</a> &middot;
-  <a href="http://127.0.0.1:43110/1Apr5ba6u9Nz6eFASmFrefGvyBKkM76QgE">Russian</a> &middot;
-  <a href="http://127.0.0.1:43110/193psz3yGj7EH39nyKb4A2KKBXEHT49Csf">Ukrainian</a> &middot;
+  <a href="http://127.0.0.1:43110/1Apr5ba6u9Nz6eFASmFrefGvyBKkM76QgE">Русский</a> &middot;
+  <a href="http://127.0.0.1:43110/193psz3yGj7EH39nyKb4A2KKBXEHT49Csf">Українська</a> &middot;
   <a href="http://127.0.0.1:43110/NewGFWTalk.bit">中文论坛</a>
  </div>
 </div>


### PR DESCRIPTION
There were many examples where the other language zites were in English, like "German" instead of "Deutsch". Yet, some were in their native language, such as "Français".
This commit should make them all consistently in their native language.