### PR TITLE
Closes #37 "comment" if 1, "comments" if plural

### DIFF
--- a/js/TopicList.coffee
+++ b/js/TopicList.coffee
@@ -298,9 +298,12 @@ class TopicList extends Class
 			if topic.type == "group"
 				$(".comment-num", elem).text "last activity"
 				$(".added", elem).text Time.since(last_action)
-			else if topic.comments_num > 0
+			else if topic.comments_num == 1
 				$(".comment-num", elem).text "#{topic.comments_num} comment"
-				$(".added", elem).text "last "+Time.since(last_action)
+				$(".added", elem).text "last " + Time.since(last_action)
+			else if topic.comments_num > 0
+				$(".comment-num", elem).text "#{topic.comments_num} comments"
+				$(".added", elem).text "last " + Time.since(last_action)
 			else
 				$(".comment-num", elem).text "0 comments"
 				$(".added", elem).text Time.since(last_action)


### PR DESCRIPTION
Before, if there were more than 0 comments, it would say, for example, "3 comment", instead of "3 comments". I added logic to change that to be "comment" when there was one comment, and "comments" when plural (in addition to "comments" when 0).