### PR TITLE
Closes #1: Start votes at 0

### DIFF
--- a/js/TopicList.coffee
+++ b/js/TopicList.coffee
@@ -132,7 +132,7 @@ class TopicList extends Class
 			 topic_creator_content.directory AS topic_creator_address,
 			 topic.topic_id || '_' || topic_creator_content.directory AS row_topic_uri,
 			 NULL AS row_topic_sub_uri, NULL AS row_topic_sub_title,
-			 (SELECT COUNT(*) FROM topic_vote WHERE topic_vote.topic_uri = topic.topic_id || '_' || topic_creator_content.directory)+1 AS votes,
+			 (SELECT COUNT(*) FROM topic_vote WHERE topic_vote.topic_uri = topic.topic_id || '_' || topic_creator_content.directory) AS votes,
 			 CASE topic.topic_id || '_' || topic_creator_content.directory #{sql_sticky} ELSE 0 END AS sticky
 			FROM topic
 			LEFT JOIN json AS topic_creator_json ON (topic_creator_json.json_id = topic.json_id)
@@ -159,7 +159,7 @@ class TopicList extends Class
 				 topic.topic_id || '_' || topic_creator_content.directory AS row_topic_uri,
 				 topic_sub.topic_id || '_' || topic_sub_creator_content.directory AS row_topic_sub_uri,
 				 topic_sub.title AS topic_sub_title,
-				 (SELECT COUNT(*) FROM topic_vote WHERE topic_vote.topic_uri = topic.topic_id || '_' || topic_creator_content.directory)+1 AS votes,
+				 (SELECT COUNT(*) FROM topic_vote WHERE topic_vote.topic_uri = topic.topic_id || '_' || topic_creator_content.directory) AS votes,
 				 CASE topic.topic_id || '_' || topic_creator_content.directory #{sql_sticky} ELSE 0 END AS sticky
 				FROM topic
 				LEFT JOIN json AS topic_creator_json ON (topic_creator_json.json_id = topic.json_id)

--- a/js/TopicShow.coffee
+++ b/js/TopicShow.coffee
@@ -63,7 +63,7 @@ class TopicShow extends Class
 		  topic_creator_user.value AS topic_creator_user_name,
 		  topic_creator_content.directory AS topic_creator_address,
 		  topic.topic_id || '_' || topic_creator_content.directory AS row_topic_uri,
-		  (SELECT COUNT(*) FROM topic_vote WHERE topic_vote.topic_uri = topic.topic_id || '_' || topic_creator_content.directory)+1 AS votes
+		  (SELECT COUNT(*) FROM topic_vote WHERE topic_vote.topic_uri = topic.topic_id || '_' || topic_creator_content.directory) AS votes
 		 FROM topic
 		  LEFT JOIN json AS topic_creator_json ON (topic_creator_json.json_id = topic.json_id)
 		  LEFT JOIN json AS topic_creator_content ON (topic_creator_content.directory = topic_creator_json.directory AND topic_creator_content.file_name = 'content.json')
@@ -111,7 +111,7 @@ class TopicShow extends Class
 			 comment.*,
 			 user.value AS user_name,
 			 user_json_content.directory AS user_address,
-			 (SELECT COUNT(*) FROM comment_vote WHERE comment_vote.comment_uri = comment.comment_id || '_' || user_json_content.directory)+1 AS votes
+			 (SELECT COUNT(*) FROM comment_vote WHERE comment_vote.comment_uri = comment.comment_id || '_' || user_json_content.directory) AS votes
 			FROM comment
 			 LEFT JOIN json AS user_json_data ON (user_json_data.json_id = comment.json_id)
 			 LEFT JOIN json AS user_json_content ON (user_json_content.directory = user_json_data.directory AND user_json_content.file_name = 'content.json')


### PR DESCRIPTION
Previously comments and topics started with a value of 1, to which a user could add an additional vote - whether their own comment or topic or otherwise. Now we start votes at 0, so that it feels less strange that you upvote yourself to get to 1 vote. In the future, creating a topic or comment may automatically submit a vote for your new topic or comment, and this commit lays the foundation for that change.