### PR TITLE
Add KxoId support

### DIFF
--- a/data-default/users/content-default.json
+++ b/data-default/users/content-default.json
@@ -7,7 +7,7 @@
   }, 
   "user_contents": {
     "cert_signers": {
-      "zeroid.bit": [ "1iD5ZQJMNXu43w1qLB8sfdHVKppVMduGz" ]
+      "zeroid.bit": [ "1iD5ZQJMNXu43w1qLB8sfdHVKppVMduGz" ],
       "kxoid.bit": [ "12F5SvxoPR128aiudte78h8pY7mobroG6V" ]
     }, 
     "permission_rules": {

--- a/data-default/users/content-default.json
+++ b/data-default/users/content-default.json
@@ -8,6 +8,7 @@
   "user_contents": {
     "cert_signers": {
       "zeroid.bit": [ "1iD5ZQJMNXu43w1qLB8sfdHVKppVMduGz" ]
+      "kxoid.bit": [ "12F5SvxoPR128aiudte78h8pY7mobroG6V" ]
     }, 
     "permission_rules": {
       ".*": {

--- a/data/users/content.json
+++ b/data/users/content.json
@@ -7,7 +7,8 @@
  },
  "user_contents": {
   "cert_signers": {
-   "zeroid.bit": [ "1iD5ZQJMNXu43w1qLB8sfdHVKppVMduGz" ]
+   "zeroid.bit": [ "1iD5ZQJMNXu43w1qLB8sfdHVKppVMduGz" ],
+   "kxoid.bit": [ "12F5SvxoPR128aiudte78h8pY7mobroG6V" ]
   },
   "permission_rules": {
    ".*": {

--- a/js/TopicList.coffee
+++ b/js/TopicList.coffee
@@ -361,7 +361,7 @@ class TopicList extends Class
 	submitCreateTopic: ->
 		# if not Page.hasOpenPort() then return false
 		if not Page.site_info.cert_user_id # No selected cert
-			Page.cmd "certSelect", [["zeroid.bit"]]
+			Page.cmd "certSelect", [["zeroid.bit", "kxoid.bit"]]
 			return false
 
 		title = $(".topic-new #topic_title").val().trim()
@@ -400,7 +400,7 @@ class TopicList extends Class
 
 	submitTopicVote: (e) =>
 		if not Page.site_info.cert_user_id # No selected cert
-			Page.cmd "certSelect", [["zeroid.bit"]]
+			Page.cmd "certSelect", [["zeroid.bit", "kxoid.bit"]]
 			return false
 
 		elem = $(e.currentTarget)

--- a/js/User.coffee
+++ b/js/User.coffee
@@ -33,7 +33,7 @@ class User extends Class
 			if Page.server_info.rev < 160
 				Page.cmd "wrapperNotification", ["error", "Comments requires at least ZeroNet 0.3.0 Please upgade!"]
 			else
-				Page.cmd "certSelect", [["zeroid.bit"]]
+				Page.cmd "certSelect", [["zeroid.bit", "kxoid.bit"]]
 			return false
 
 

--- a/js/all.js
+++ b/js/all.js
@@ -1634,7 +1634,7 @@ jQuery.extend( jQuery.easing,
     TopicList.prototype.submitTopicVote = function(e) {
       var elem, inner_path;
       if (!Page.site_info.cert_user_id) {
-        Page.cmd("certSelect", [["zeroid.bit"]]);
+        Page.cmd("certSelect", [["zeroid.bit", "kxoid.bit"]]);
         return false;
       }
       elem = $(e.currentTarget);
@@ -2027,7 +2027,7 @@ jQuery.extend( jQuery.easing,
           if (Page.server_info.rev < 160) {
             Page.cmd("wrapperNotification", ["error", "Comments requires at least ZeroNet 0.3.0 Please upgade!"]);
           } else {
-            Page.cmd("certSelect", [["zeroid.bit"]]);
+            Page.cmd("certSelect", [["zeroid.bit", "kxoid.bit"]]);
           }
           return false;
         };

--- a/js/all.js
+++ b/js/all.js
@@ -1587,7 +1587,7 @@ jQuery.extend( jQuery.easing,
     TopicList.prototype.submitCreateTopic = function() {
       var body, title;
       if (!Page.site_info.cert_user_id) {
-        Page.cmd("certSelect", [["zeroid.bit"]]);
+        Page.cmd("certSelect", [["zeroid.bit", "kxoid.bit"]]);
         return false;
       }
       title = $(".topic-new #topic_title").val().trim();


### PR DESCRIPTION
Edit: KxoId offers Unique Ids. The registration requests happen within the ZeroNet network by using PeerMessage to *broadcast* registration requests. This allows people to still register even if their government has blocked the server's ip - as long as there is some path of peers connecting from their client to the server. Additionally, IP addresses are never leaked, and can be hidden with Tor.